### PR TITLE
Added options param for authenticate() method

### DIFF
--- a/lib/passport-readability/strategy.js
+++ b/lib/passport-readability/strategy.js
@@ -60,9 +60,10 @@ util.inherits(Strategy, OAuthStrategy);
  * Authenticate request by delegating to Readability using OAuth.
  *
  * @param {Object} req
+ * @param {Object} options
  * @api protected
  */
-Strategy.prototype.authenticate = function(req) {
+Strategy.prototype.authenticate = function(req, options) {
   // When a user denies authorization on Readability, they are presented with a
   // link to return to the application in the following format:
   //
@@ -75,7 +76,7 @@ Strategy.prototype.authenticate = function(req) {
   }
   
   // Call the base class for standard OAuth authentication.
-  OAuthStrategy.prototype.authenticate.call(this, req);
+  OAuthStrategy.prototype.authenticate.call(this, req, options);
 }
 
 /**


### PR DESCRIPTION
Allowing callbackURL to be set upon the passport.authenticate() call:

``` javascript
app.get('/auth/readability',
        passport.authenticate('readability', { callbackURL: '/callback' }));
```
